### PR TITLE
Updated `actix_web` to stable version and fixed imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ repository = "https://github.com/PiyushXCoder/actix-web-4-validator"
 documentation = "https://docs.rs/actix-web-4-validator/"
 
 [dependencies]
-actix-web = { version = "4.0.0-rc.3", default-features = false }
+actix-web = { version = "4.0.1", default-features = false }
 # actix-http = { version = "2" }
 # derive_more = "0.99"
 validator = { version = "0.14" }

--- a/src/qsquery.rs
+++ b/src/qsquery.rs
@@ -204,10 +204,7 @@ where
 
     /// Builds Query struct from request and provides validation mechanism
     #[inline]
-    fn from_request(
-        req: &actix_web::web::HttpRequest,
-        _: &mut actix_web::dev::Payload,
-    ) -> Self::Future {
+    fn from_request(req: &actix_web::HttpRequest, _: &mut actix_web::dev::Payload) -> Self::Future {
         let query_config = req.app_data::<QsQueryConfig>();
 
         let error_handler = query_config.map(|c| c.ehandler.clone()).unwrap_or(None);

--- a/src/query.rs
+++ b/src/query.rs
@@ -202,10 +202,7 @@ where
 
     /// Builds Query struct from request and provides validation mechanism
     #[inline]
-    fn from_request(
-        req: &actix_web::web::HttpRequest,
-        _: &mut actix_web::dev::Payload,
-    ) -> Self::Future {
+    fn from_request(req: &actix_web::HttpRequest, _: &mut actix_web::dev::Payload) -> Self::Future {
         let error_handler = req
             .app_data::<QueryConfig>()
             .map(|c| c.ehandler.clone())


### PR DESCRIPTION
The stable version of `actix_web@4` has been released yesterday, here is a PR to update the cargo deps version and fix an import error